### PR TITLE
Fix duplicate name field in rbac and add kustomize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ The system watches both the PullSecret and source Secret objects for changes.
 The operator will add or remove secrets from namespaces as the `PullSecret` changes, as well as update the value of the `secrets` if the source secrets change.
 
 ## How to install
+
+### Kustomize
+The kustomize folder contains a simple raw yaml deployment, generated using `helm template` and default values.
+
+### Helm
 There is a helm chart in the charts/pull-secret-operator directory of this repository.
 It will deploy the CRD and a Deployment spec, as well as setup very liberal RBAC rules that give it access to read and edit all secrets in your deployment.
+
 I may adjust the chart to have configurable namespaces enabled in the RBAC at a later date.
 
 ## Speaking of RBAC, isn't this insecure?

--- a/chart/pull-secret-operator/Chart.yaml
+++ b/chart/pull-secret-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/pull-secret-operator/templates/rbac.yaml
+++ b/chart/pull-secret-operator/templates/rbac.yaml
@@ -2,10 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "pull-secret-operator.fullname" . }}
+  name: {{ include "pull-secret-operator.name" . }}-read
   labels:
     {{- include "pull-secret-operator.labels" . | nindent 4 }}
-  name: {{ include "pull-secret-operator.name" . }}-read
 rules:
 - apiGroups:
   - vsix.me
@@ -25,10 +24,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "pull-secret-operator.fullname" . }}
+  name: {{ include "pull-secret-operator.name" . }}-read-binding
   labels:
     {{- include "pull-secret-operator.labels" . | nindent 4 }}
-  name: {{ include "pull-secret-operator.name" .}}-read-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -1,0 +1,123 @@
+---
+# Source: pull-secret-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pull-secret-operator
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+---
+# Source: pull-secret-operator/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pull-secret-operator-read
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+rules:
+  - apiGroups:
+      - vsix.me
+    resources:
+      - pullsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - '*'
+---
+# Source: pull-secret-operator/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pull-secret-operator-read-binding
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pull-secret-operator-read
+subjects:
+  - kind: ServiceAccount
+    name: pull-secret-operator
+    namespace: default
+---
+# Source: pull-secret-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pull-secret-operator
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: pull-secret-operator
+---
+# Source: pull-secret-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pull-secret-operator
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pull-secret-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pull-secret-operator
+    spec:
+      serviceAccountName: pull-secret-operator
+      securityContext: {}
+      containers:
+        - name: pull-secret-operator
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: "docker.io/petergrace/pull-secret-operator:0.1.9"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 9898
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources: {}
+---
+# Source: pull-secret-operator/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "pull-secret-operator-test-connection"
+  labels:
+    app.kubernetes.io/name: pull-secret-operator
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['pull-secret-operator:80']
+  restartPolicy: Never

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Optionally uncomment to make release unique.
+# prefix: release-name-
+
+# Override the default cluster image version.
+images:
+  - name: "docker.io/petergrace/pull-secret-operator"
+    newTag: "0.1.9"
+
+resources:
+  - deployment.yaml


### PR DESCRIPTION
When generating the chart yaml, I noticed `name` is defined twice in the `ClusterRole` and `ClusterRoleBinding`.

I removed the duplicate, and added a very simple kustomize example deploy.